### PR TITLE
Fix issue 4 - Correct signature of NotificationTypePurger::run()

### DIFF
--- a/code/NotificationPurgeTask.php
+++ b/code/NotificationPurgeTask.php
@@ -25,10 +25,10 @@ class NotificationPurgeTask extends BuildTask
 
     /**
      * @inheritDoc
-     * @param  SS_HTTPRequest $request HTTP Request.
+     * @param  mixed $request HTTP Request.
      * @return void
      */
-    public function run(SS_HTTPRequest $request)
+    public function run($request)
     {
         // Get all types not in the default list
         $defaultRecords = NotificationType::config()->get('default_records', Config::UNINHERITED);

--- a/tests/Models/NotificationTypeTest.php
+++ b/tests/Models/NotificationTypeTest.php
@@ -34,11 +34,11 @@ class NotificationTypeTest extends SapphireTest
         /**
          * @var NotificationType
          */
-        $singleton = NotificationType::singleton();
-        $singleton->config()->update('default_records', [
+        Config::inst()->update('NotificationType', 'default_records', [
             ['SystemName' => 'TestOne', 'Name' => 'Test One'],
             ['SystemName' => 'TestTwo', 'Name' => 'Test Two'],
         ]);
+        $singleton = NotificationType::singleton();
         $singleton->requireDefaultRecords();
 
         $t1 = NotificationType::bySystemName('TestOne');

--- a/tests/Models/NotificationTypeTest.php
+++ b/tests/Models/NotificationTypeTest.php
@@ -28,4 +28,31 @@ class NotificationTypeTest extends SapphireTest
             '`bySystemName` should return null when provided a invalid system name'
         );
     }
+
+    public function testDefaultRecords()
+    {
+        /**
+         * @var NotificationType
+         */
+        $singleton = NotificationType::singleton();
+        $singleton->config()->update('default_records', [
+            ['SystemName' => 'TestOne', 'Name' => 'Test One'],
+            ['SystemName' => 'TestTwo', 'Name' => 'Test Two'],
+        ]);
+        $singleton->requireDefaultRecords();
+
+        $t1 = NotificationType::bySystemName('TestOne');
+        $this->assertNotEmpty(
+            $t1,
+            'Notification Type with a System name of TestOne should have been created.'
+        );
+        $this->assertEquals('Test One', $t1->Name, 'TestOne should have been created with a Name of "Test One"');
+
+        $t2 = NotificationType::bySystemName('TestTwo');
+        $this->assertNotEmpty(
+            $t2,
+            'Notification Type with a System name of TestTwo should have been created.'
+        );
+        $this->assertEquals('Test Two', $t2->Name, 'TestTwo should have been created with a Name of "Test Two"');
+    }
 }

--- a/tests/NotificationPurgeTaskTest.php
+++ b/tests/NotificationPurgeTaskTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * Test registion for Immunoglobin
+ */
+class NotificationPurgeTaskTest extends SapphireTest
+{
+    protected static $fixture_file = 'NotificationPurgeTaskTest.yml';
+    protected $usesDatabase = true;
+
+    public function testRun()
+    {
+        $singleton = NotificationType::singleton();
+        $singleton->config()->update('default_records', [
+            ['SystemName' => 'TestOne', 'Name' => 'Test One'],
+            ['SystemName' => 'TestTwo', 'Name' => 'Test Two'],
+        ]);
+
+        NotificationPurgeTask::singleton()->run(new NotificationPurgeTask());
+
+        $this->assertEmpty(NotificationType::bySystemName('boom'), 'Boom Notification Type should have been removed by NotificationPurgeTask.');
+        $this->assertNotEmpty(NotificationType::bySystemName('TestOne'), 'TestOne Notification Type should still be there.');
+    }
+}

--- a/tests/NotificationPurgeTaskTest.php
+++ b/tests/NotificationPurgeTaskTest.php
@@ -10,13 +10,15 @@ class NotificationPurgeTaskTest extends SapphireTest
 
     public function testRun()
     {
-        $singleton = NotificationType::singleton();
-        $singleton->config()->update('default_records', [
+        Config::inst()->update('NotificationType', 'default_records', [
             ['SystemName' => 'TestOne', 'Name' => 'Test One'],
             ['SystemName' => 'TestTwo', 'Name' => 'Test Two'],
         ]);
 
+        $singleton = NotificationType::singleton();
+        ob_start(); // Suppress output
         NotificationPurgeTask::singleton()->run(new NotificationPurgeTask());
+        ob_get_clean(); // Unsuppress output
 
         $this->assertEmpty(NotificationType::bySystemName('boom'), 'Boom Notification Type should have been removed by NotificationPurgeTask.');
         $this->assertNotEmpty(NotificationType::bySystemName('TestOne'), 'TestOne Notification Type should still be there.');

--- a/tests/NotificationPurgeTaskTest.yml
+++ b/tests/NotificationPurgeTaskTest.yml
@@ -1,0 +1,10 @@
+NotificationType:
+  boom:
+    SystemName: boom
+    Name: "Boom!"
+    ShortMessageFormat: "Short: FirstName = $Member.FirstName AND Foo = $Foo"
+    SubjectFormat: "Subject: FirstName = $Member.FirstName AND Foo = $Foo"
+    RichMessageFormat: "<strong>Rich</strong>: FirstName = $Member.FirstName AND Foo = $Foo"
+  testOne:
+    SystemName: TestOne
+    Name: "Test One"


### PR DESCRIPTION
Corrected the signature of `NotificationTypePurger::run()` to be compatible with `BuildTask` and write related Test case.